### PR TITLE
Fixes course prediction before retrieval

### DIFF
--- a/Train/train.py
+++ b/Train/train.py
@@ -464,7 +464,7 @@ def train(train_loader, train_transform, model, model_icr, model_pfr, model_prp,
         absolute_t1 = torch.cat([absolute_t1, absolute_t2, absolute_t3],0)
         
         course_t = absolute_t1 - trans.squeeze(3).squeeze(2).data.cpu()
-        course_r = get_coarse_quaternion(absolute_r1, quat.squeeze(3).squeeze(2).data.cpu() * [1, -1, -1, -1])
+        course_r = get_coarse_quaternion(absolute_r1, quat.squeeze(3).squeeze(2).data.cpu() * np.array([1, -1, -1, -1], np.float32))
         course_rt = torch.cat([course_r, course_t], 1).numpy()
         #print(anchor_name, absolute_r1.size(), quat.size(), course_t, course_r)
         

--- a/Train/train.py
+++ b/Train/train.py
@@ -463,8 +463,8 @@ def train(train_loader, train_transform, model, model_icr, model_pfr, model_prp,
         absolute_r1 = torch.cat([absolute_r1, absolute_r2, absolute_r3],0)
         absolute_t1 = torch.cat([absolute_t1, absolute_t2, absolute_t3],0)
         
-        course_t = absolute_t1 + trans.squeeze(3).squeeze(2).data.cpu()
-        course_r = get_coarse_quaternion(absolute_r1, quat.squeeze(3).squeeze(2).data.cpu())
+        course_t = absolute_t1 - trans.squeeze(3).squeeze(2).data.cpu()
+        course_r = get_coarse_quaternion(absolute_r1, quat.squeeze(3).squeeze(2).data.cpu() * [1, -1, -1, -1])
         course_rt = torch.cat([course_r, course_t], 1).numpy()
         #print(anchor_name, absolute_r1.size(), quat.size(), course_t, course_r)
         


### PR DESCRIPTION
The way the course prediction is currently done is not correct. As also stated in the paper, anchor translation `t_1` can be estimated via `t_2 - \delta_t` and the anchor rotational part `R_1` can be estimated via `R_2 * \delta_R ^ -1`.